### PR TITLE
SQLighterRsImpl: make getLongWithInt not truncate values to int

### DIFF
--- a/ios/j2objc/com/vals/a2ios/sqlighter/impl/SQLighterRsImpl.m
+++ b/ios/j2objc/com/vals/a2ios/sqlighter/impl/SQLighterRsImpl.m
@@ -56,7 +56,11 @@
 }
 
 -(JavaLangLong*) getLongWithInt: (int) idx {
-    return [JavaLangLong valueOfWithLong: [[self getIntWithInt:idx] longValue]];
+    if ([self isNullWithInt:idx]) {
+        return nil;
+    }
+    sqlite3_int64 l = sqlite3_column_int64(stmt, idx++);
+    return [JavaLangLong valueOfWithLong:l];
 }
 
 -(JavaLangDouble*) getDoubleWithInt: (int) idx {


### PR DESCRIPTION
Before this fix, long values in a result set get incorrectly truncated to int length which leads to retrieval of incorrect values for any higher-value longs stored in the DB.